### PR TITLE
MAINT: Add better error handling in linalg.norm for vectors and clari…

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2434,6 +2434,9 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
     The nuclear norm is the sum of the singular values.
 
+    Both the Frobenius and nuclear norm orders are only defined for
+    matrices and raise a ValueError when ``x.ndim != 2``.
+
     References
     ----------
     .. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*,
@@ -2556,11 +2559,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
             # special case for speedup
             s = (x.conj() * x).real
             return sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
+        # None of the str-type keywords for ord ('fro', 'nuc') 
+        # are valid for vectors
+        elif isinstance(ord, str):
+            raise ValueError(f"Invalid norm order '{ord}' for vectors")
         else:
-            try:
-                ord + 1
-            except TypeError:
-                raise ValueError("Invalid norm order for vectors.")
             absx = abs(x)
             absx **= ord
             ret = add.reduce(absx, axis=axis, keepdims=keepdims)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1480,11 +1480,12 @@ class _TestNorm2D(_TestNormBase):
 
         # Using `axis=<integer>` or passing in a 1-D array implies vector
         # norms are being computed, so also using `ord='fro'`
-        # or `ord='nuc'` raises a ValueError.
+        # or `ord='nuc'` or any other string raises a ValueError.
         assert_raises(ValueError, norm, A, 'fro', 0)
         assert_raises(ValueError, norm, A, 'nuc', 0)
         assert_raises(ValueError, norm, [3, 4], 'fro', None)
         assert_raises(ValueError, norm, [3, 4], 'nuc', None)
+        assert_raises(ValueError, norm, [3, 4], 'test', None)
 
         # Similarly, norm should raise an exception when ord is any finite
         # number other than 1, 2, -1 or -2 when computing matrix norms.

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -57,8 +57,8 @@ class TestRegression:
         assert_array_almost_equal(b, np.zeros((2, 2)))
 
     def test_norm_vector_badarg(self):
-        # Regression for #786: Froebenius norm for vectors raises
-        # TypeError.
+        # Regression for #786: Frobenius norm for vectors raises
+        # ValueError.
         assert_raises(ValueError, linalg.norm, array([1., 2., 3.]), 'fro')
 
     def test_lapack_endian(self):


### PR DESCRIPTION
…fy it in documentation (#15740)

* Clarify `fro` and `nuc` usage in linalg.norm documentation
  (see #15533).
* Add improved error handling when getting Frobenius norm from
  a vector (see #15533).
* Fix comment in linalg norm test.

Closes gh-15533.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
